### PR TITLE
Remove unnecessary batching logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,6 @@ TABLE_NAME = "recipes"
 TEXT_MODEL_NAME = "nomic-embed-text"
 TEXT_EMBED_DIM = 768
 IMAGE_MODEL_NAME = "openai/clip-vit-base-patch32"
-FEATURE_BATCH_SIZE = 10
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
 OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
 
@@ -203,39 +202,21 @@ def build_feature_input(recipe_id: int, ingredients: list[str] | None) -> Recipe
     return RecipeFeatureInput(id=recipe_id, ingredients=ingredients)
 
 
-@cocoindex.op.function(batching=True, max_batch_size=FEATURE_BATCH_SIZE)
-async def extract_features_batch(
-    inputs: list[RecipeFeatureInput],
-) -> list[RecipeFeatureOutput]:
+@cocoindex.op.function()
+async def extract_features(recipe: RecipeFeatureInput) -> RecipeFeatureOutput:
     extractor = Extract()
-    tasks: list[asyncio.Task[Prediction]] = []
-    pending_idx: list[int] = []
-    for idx, recipe in enumerate(inputs):
-        pending_idx.append(idx)
-        tasks.append(asyncio.create_task(extractor.aforward(recipe=recipe)))
+    prediction = await extractor.aforward(recipe=recipe)
+    if prediction is None:
+        return RecipeFeatureOutput(id=recipe.id)
 
-    predictions: list[Prediction | None] = [None] * len(inputs)
-    if tasks:
-        results = await asyncio.gather(*tasks)
-        for idx, pred in zip(pending_idx, results):
-            predictions[idx] = pred
-
-    features: list[RecipeFeatureOutput] = []
-    for item, pred in zip(inputs, predictions):
-        if pred is None:
-            features.append(RecipeFeatureOutput(id=item.id))
-            continue
-        features.append(
-            RecipeFeatureOutput(
-                id=item.id,
-                is_vegetarian=pred.get("is_vegetarian"),
-                has_nuts=pred.get("has_nuts"),
-                has_dairy=pred.get("has_dairy"),
-                has_eggs=pred.get("has_eggs"),
-                category=pred.get("category"),
-            )
-        )
-    return features
+    return RecipeFeatureOutput(
+        id=recipe.id,
+        is_vegetarian=prediction.get("is_vegetarian"),
+        has_nuts=prediction.get("has_nuts"),
+        has_dairy=prediction.get("has_dairy"),
+        has_eggs=prediction.get("has_eggs"),
+        category=prediction.get("category"),
+    )
 
 
 # --- CocoIndex flow definition ---
@@ -276,7 +257,7 @@ def recipe_ingest_flow(
             feature_input = recipe["id"].transform(
                 build_feature_input, ingredients=recipe["ingredients"]
             )
-            recipe["features"] = feature_input.transform(extract_features_batch)
+            recipe["features"] = feature_input.transform(extract_features)
 
             recipe_embeddings.collect(
                 id=recipe["id"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "cocoindex>=0.3.22",
+    "cocoindex>=0.3.25",
     "dspy>=3.0.4",
     "einops>=0.8.1",
     "fastapi>=0.128.0",

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "cocoindex"
-version = "0.3.22"
+version = "0.3.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -262,13 +262,13 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/1c/9fe8481691bddebe616d4c79559a4cbfd2b406bc94fabee9cc41bf1b88f9/cocoindex-0.3.22.tar.gz", hash = "sha256:b44ea76808a596bbe709d85d8d0e5e6b59968f91fcfb7e6b260ebc383fe9ab11", size = 383300, upload-time = "2025-12-27T00:54:33.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/fe/b3ac484b7df7b5380dee26e0e42aa4d6dbdbc81f214ba43eb5f66ea0b80d/cocoindex-0.3.25.tar.gz", hash = "sha256:090e46c04849812872b6aa85a4c59ffb2995149bac6ad6c49e19e2226fbfa7e4", size = 388018, upload-time = "2026-01-09T08:47:52.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/9b/ccd8d6653c9c0c9eac8bf16fd6b41f359b303be84ad09c7fe90474a05733/cocoindex-0.3.22-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7488f4f42c7341b0713fe0ed8ad39b12e54742b7bf985ea748814d57bc860b90", size = 18038513, upload-time = "2025-12-27T00:54:31.184Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/65/5fac1f85823b1c42bbad9a24f7dcb27069336c30ee35f19e712bd624b06d/cocoindex-0.3.22-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:96bc72e54bf9443d4d851a94632effa8f4ce72b576e7458e17e951578493e165", size = 17370061, upload-time = "2025-12-27T00:54:28.781Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5c/8f310f3039b23ad943ed06793bc35b8363554778d0db13e0c9521548ff0a/cocoindex-0.3.22-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:065b93bddca03f2bc91e9e99de828737c6e53b1090d1a46039dc96ce1ad012f2", size = 17854728, upload-time = "2025-12-27T00:54:23.582Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6d/cb44176c86b1842bc44755c9bf5a43420291a533b0dbe98c13850f5db70b/cocoindex-0.3.22-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:49910292bcf14ed8e4af01c2431f0e0606d20f0532571e17fbce4f607f9eb323", size = 18498030, upload-time = "2025-12-27T00:54:26.27Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/3f/4d88666f8517bbf11dcc9fdd7cde29875afa4a2c8e698b4c67079ca792ab/cocoindex-0.3.22-cp311-abi3-win_amd64.whl", hash = "sha256:adbe85a7f4324452010b881ab08c330433d06e66e34cfa7e02b9aaabb9540449", size = 19054759, upload-time = "2025-12-27T00:54:34.655Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/2f8ccf6de62d545140fff1900c4a7f598be1ebf550075ebb0886224fe2e0/cocoindex-0.3.25-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:926122641a4383a0c55d7c30988a65db305be5038dc2ac19e508f9fc1617f815", size = 18049039, upload-time = "2026-01-09T08:47:50.119Z" },
+    { url = "https://files.pythonhosted.org/packages/74/68/d44a301eddf8e831fde9caf145ed43d245e4dbc8e55328aee2700913746e/cocoindex-0.3.25-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:021e6c27939644de691d5fcf5b0c7c54586ec626f51d3e6b2eb8e7409fc31850", size = 17382216, upload-time = "2026-01-09T08:47:48.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e6/a6941f4ff46c30a73596dd40a98d264b84f7d251a3d726eada40955d7881/cocoindex-0.3.25-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:90a90f0e645cbef5c2b73327ce82192c3e55466d59050db2a1f7610ceeaf1cce", size = 17874515, upload-time = "2026-01-09T08:47:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8d/5a72ceb486580b28aed0d5cbbc9eee55f00875ffe45c6984bc0392aa1275/cocoindex-0.3.25-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c023cd9e4bf00b0cf86e9103b1c91d4fb90d77e0220cb27ba232bca8aef5081", size = 18502628, upload-time = "2026-01-09T08:47:45.867Z" },
+    { url = "https://files.pythonhosted.org/packages/61/4e/6d560a679ed5f9f5dd319ea1649c3ef665329f8e078b94e1c8517bdf3020/cocoindex-0.3.25-cp311-abi3-win_amd64.whl", hash = "sha256:a562006e78996d593ab7b2ebb4494d1596befe522d59e73a5962531b97416b4e", size = 19072788, upload-time = "2026-01-09T08:47:54.441Z" },
 ]
 
 [[package]]
@@ -293,7 +293,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cocoindex", specifier = ">=0.3.22" },
+    { name = "cocoindex", specifier = ">=0.3.25" },
     { name = "dspy", specifier = ">=3.0.4" },
     { name = "einops", specifier = ">=0.8.1" },
     { name = "fastapi", specifier = ">=0.128.0" },
@@ -1548,30 +1548,30 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "7.2.0"
+version = "7.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/7c/31d1c3ceb1260301f87565f50689dc6da3db427ece1e1e012af22abca54e/psutil-7.2.0.tar.gz", hash = "sha256:2e4f8e1552f77d14dc96fb0f6240c5b34a37081c0889f0853b3b29a496e5ef64", size = 489863, upload-time = "2025-12-23T20:26:24.616Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/cb/09e5184fb5fc0358d110fc3ca7f6b1d033800734d34cac10f4136cfac10e/psutil-7.2.1.tar.gz", hash = "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3", size = 490253, upload-time = "2025-12-29T08:26:00.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/8e/b35aae6ed19bc4e2286cac4832e4d522fcf00571867b0a85a3f77ef96a80/psutil-7.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c31e927555539132a00380c971816ea43d089bf4bd5f3e918ed8c16776d68474", size = 129593, upload-time = "2025-12-23T20:26:28.019Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a2/773d17d74e122bbffe08b97f73f2d4a01ef53fb03b98e61b8e4f64a9c6b9/psutil-7.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:db8e44e766cef86dea47d9a1fa535d38dc76449e5878a92f33683b7dba5bfcb2", size = 130104, upload-time = "2025-12-23T20:26:30.27Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/e3/d3a9b3f4bd231abbd70a988beb2e3edd15306051bccbfc4472bd34a56e01/psutil-7.2.0-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85ef849ac92169dedc59a7ac2fb565f47b3468fbe1524bf748746bc21afb94c7", size = 180579, upload-time = "2025-12-23T20:26:32.628Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f8/6c73044424aabe1b7824d4d4504029d406648286d8fe7ba8c4682e0d3042/psutil-7.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26782bdbae2f5c14ce9ebe8ad2411dc2ca870495e0cd90f8910ede7fa5e27117", size = 183171, upload-time = "2025-12-23T20:26:34.972Z" },
-    { url = "https://files.pythonhosted.org/packages/48/7d/76d7a863340885d41826562225a566683e653ee6c9ba03c9f3856afa7d80/psutil-7.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b7665f612d3b38a583391b95969667a53aaf6c5706dc27a602c9a4874fbf09e4", size = 139055, upload-time = "2025-12-23T20:26:36.848Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/48/200054ada0ae4872c8a71db54f3eb6a9af4101680ee6830d373b7fda526b/psutil-7.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:4413373c174520ae28a24a8974ad8ce6b21f060d27dde94e25f8c73a7effe57a", size = 134737, upload-time = "2025-12-23T20:26:38.784Z" },
-    { url = "https://files.pythonhosted.org/packages/44/86/98da45dff471b93ef5ce5bcaefa00e3038295a7880a77cf74018243d37fb/psutil-7.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2f2f53fd114e7946dfba3afb98c9b7c7f376009447360ca15bfb73f2066f84c7", size = 129692, upload-time = "2025-12-23T20:26:40.623Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ee/10eae91ba4ad071c92db3c178ba861f30406342de9f0ddbe6d51fd741236/psutil-7.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e65c41d7e60068f60ce43b31a3a7fc90deb0dfd34ffc824a2574c2e5279b377e", size = 130110, upload-time = "2025-12-23T20:26:42.569Z" },
-    { url = "https://files.pythonhosted.org/packages/87/3a/2b2897443d56fedbbc34ac68a0dc7d55faa05d555372a2f989109052f86d/psutil-7.2.0-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc66d21366850a4261412ce994ae9976bba9852dafb4f2fa60db68ed17ff5281", size = 181487, upload-time = "2025-12-23T20:26:44.633Z" },
-    { url = "https://files.pythonhosted.org/packages/11/66/44308428f7333db42c5ea7390c52af1b38f59b80b80c437291f58b5dfdad/psutil-7.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e025d67b42b8f22b096d5d20f5171de0e0fefb2f0ce983a13c5a1b5ed9872706", size = 184320, upload-time = "2025-12-23T20:26:46.83Z" },
-    { url = "https://files.pythonhosted.org/packages/18/28/d2feadc7f18e501c5ce687c377db7dca924585418fd694272b8e488ea99f/psutil-7.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:45f6b91f7ad63414d6454fd609e5e3556d0e1038d5d9c75a1368513bdf763f57", size = 140372, upload-time = "2025-12-23T20:26:49.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/48381f5fd0425aa054c4ee3de24f50de3d6c347019f3aec75f357377d447/psutil-7.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87b18a19574139d60a546e88b5f5b9cbad598e26cdc790d204ab95d7024f03ee", size = 135400, upload-time = "2025-12-23T20:26:51.585Z" },
-    { url = "https://files.pythonhosted.org/packages/40/c5/a49160bf3e165b7b93a60579a353cf5d939d7f878fe5fd369110f1d18043/psutil-7.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:977a2fcd132d15cb05b32b2d85b98d087cad039b0ce435731670ba74da9e6133", size = 128116, upload-time = "2025-12-23T20:26:53.516Z" },
-    { url = "https://files.pythonhosted.org/packages/10/a1/c75feb480f60cd768fb6ed00ac362a16a33e5076ec8475a22d8162fb2659/psutil-7.2.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:24151011c21fadd94214d7139d7c6c54569290d7e553989bdf0eab73b13beb8c", size = 128925, upload-time = "2025-12-23T20:26:55.573Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91f211ba9279e7c61d9d8f84b713cfc38fa161cb0597d5cb3f1ca742f6848254", size = 154666, upload-time = "2025-12-23T20:26:57.312Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/dd/4c2de9c3827c892599d277a69d2224136800870a8a88a80981de905de28d/psutil-7.2.0-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f37415188b7ea98faf90fed51131181646c59098b077550246e2e092e127418b", size = 156109, upload-time = "2025-12-23T20:26:58.851Z" },
-    { url = "https://files.pythonhosted.org/packages/81/3f/090943c682d3629968dd0b04826ddcbc760ee1379021dbe316e2ddfcd01b/psutil-7.2.0-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0d12c7ce6ed1128cd81fd54606afa054ac7dbb9773469ebb58cf2f171c49f2ac", size = 148081, upload-time = "2025-12-23T20:27:01.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/88/c39648ebb8ec182d0364af53cdefe6eddb5f3872ba718b5855a8ff65d6d4/psutil-7.2.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ca0faef7976530940dcd39bc5382d0d0d5eb023b186a4901ca341bd8d8684151", size = 147376, upload-time = "2025-12-23T20:27:03.347Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a2/5b39e08bd9b27476bc7cce7e21c71a481ad60b81ffac49baf02687a50d7f/psutil-7.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:abdb74137ca232d20250e9ad471f58d500e7743bc8253ba0bfbf26e570c0e437", size = 136910, upload-time = "2025-12-23T20:27:05.289Z" },
-    { url = "https://files.pythonhosted.org/packages/59/54/53839db1258c1eaeb4ded57ff202144ebc75b23facc05a74fd98d338b0c6/psutil-7.2.0-cp37-abi3-win_arm64.whl", hash = "sha256:284e71038b3139e7ab3834b63b3eb5aa5565fcd61a681ec746ef9a0a8c457fd2", size = 133807, upload-time = "2025-12-23T20:27:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/77/8e/f0c242053a368c2aa89584ecd1b054a18683f13d6e5a318fc9ec36582c94/psutil-7.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d", size = 129624, upload-time = "2025-12-29T08:26:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/a58a4968f8990617decee234258a2b4fc7cd9e35668387646c1963e69f26/psutil-7.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49", size = 130132, upload-time = "2025-12-29T08:26:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6d/ed44901e830739af5f72a85fa7ec5ff1edea7f81bfbf4875e409007149bd/psutil-7.2.1-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc", size = 180612, upload-time = "2025-12-29T08:26:08.276Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/65/b628f8459bca4efbfae50d4bf3feaab803de9a160b9d5f3bd9295a33f0c2/psutil-7.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf", size = 183201, upload-time = "2025-12-29T08:26:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/23/851cadc9764edcc18f0effe7d0bf69f727d4cf2442deb4a9f78d4e4f30f2/psutil-7.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f", size = 139081, upload-time = "2025-12-29T08:26:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/59/82/d63e8494ec5758029f31c6cb06d7d161175d8281e91d011a4a441c8a43b5/psutil-7.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672", size = 134767, upload-time = "2025-12-29T08:26:14.528Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c2/5fb764bd61e40e1fe756a44bd4c21827228394c17414ade348e28f83cd79/psutil-7.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679", size = 129716, upload-time = "2025-12-29T08:26:16.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d2/935039c20e06f615d9ca6ca0ab756cf8408a19d298ffaa08666bc18dc805/psutil-7.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f", size = 130133, upload-time = "2025-12-29T08:26:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/19f1eb0e01d24c2b3eacbc2f78d3b5add8a89bf0bb69465bc8d563cc33de/psutil-7.2.1-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129", size = 181518, upload-time = "2025-12-29T08:26:20.241Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6d/7e18b1b4fa13ad370787626c95887b027656ad4829c156bb6569d02f3262/psutil-7.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a", size = 184348, upload-time = "2025-12-29T08:26:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/1672114392dd879586d60dd97896325df47d9a130ac7401318005aab28ec/psutil-7.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79", size = 140400, upload-time = "2025-12-29T08:26:23.993Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7b/d0e9d4513c46e46897b46bcfc410d51fc65735837ea57a25170f298326e6/psutil-7.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266", size = 135430, upload-time = "2025-12-29T08:26:25.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cf/5180eb8c8bdf6a503c6919f1da28328bd1e6b3b1b5b9d5b01ae64f019616/psutil-7.2.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42", size = 128137, upload-time = "2025-12-29T08:26:27.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2c/78e4a789306a92ade5000da4f5de3255202c534acdadc3aac7b5458fadef/psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1", size = 128947, upload-time = "2025-12-29T08:26:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8", size = 154694, upload-time = "2025-12-29T08:26:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e4/b751cdf839c011a9714a783f120e6a86b7494eb70044d7d81a25a5cd295f/psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6", size = 156136, upload-time = "2025-12-29T08:26:34.079Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ad/bbf6595a8134ee1e94a4487af3f132cef7fce43aef4a93b49912a48c3af7/psutil-7.2.1-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8", size = 148108, upload-time = "2025-12-29T08:26:36.225Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- The DSPy feature extractor had unnecessary batching logic - the incoming records are processed asynchronously, just like the entire flow itself, so there's no need for batching in this case. Batching only helps when we have workloads that need GPU, or other special cases. This PR simplifies the logic for feature extraction and makes the function easier to read. 🎉
- Also bumps the CocoIndex version to the latest release to benefit from the CLI log progress bar update in https://github.com/cocoindex-io/cocoindex/pull/1467